### PR TITLE
To match the example in the readme

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,8 +51,8 @@ app.post('/webhook/', function (req, res) {
 
 
 // recommended to inject access tokens as environmental variables, e.g.
-// const token = process.env.PAGE_ACCESS_TOKEN
-const token = "<PAGE_ACCESS_TOKEN>"
+// const token = process.env.FB_PAGE_ACCESS_TOKEN
+const token = "<FB_PAGE_ACCESS_TOKEN>"
 
 function sendTextMessage(sender, text) {
 	let messageData = { text:text }


### PR DESCRIPTION
FB_PAGE_ACCESS_TOKEN is referenced in the readme, but PAGE_ACCESS_TOKEN is provided in this file.

I didn't see the typo, I lost 10 minutes. This may happens to others. So I made a PR.
