### PR TITLE
fix "Error: Can't set headers after they are sent."

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,8 +22,9 @@ app.get('/', function (req, res) {
 app.get('/webhook/', function (req, res) {
 	if (req.query['hub.verify_token'] === 'my_voice_is_my_password_verify_me') {
 		res.send(req.query['hub.challenge'])
+	} else {
+		res.send('Error, wrong token')
 	}
-	res.send('Error, wrong token')
 })
 
 // to post data


### PR DESCRIPTION
fixes:

> 2016-10-07T07:21:44.821826+00:00 app[web.1]: Error: Can't set headers after they are sent.
> 2016-10-07T07:21:44.821843+00:00 app[web.1]:     at ServerResponse.OutgoingMessage.setHeader (_http_outgoing.js:346:11)
> 2016-10-07T07:21:44.821844+00:00 app[web.1]:     at ServerResponse.header (/app/node_modules/express/lib/response.js:719:10)
> 2016-10-07T07:21:44.821845+00:00 app[web.1]:     at ServerResponse.send (/app/node_modules/express/lib/response.js:164:12)
> 2016-10-07T07:21:44.821846+00:00 app[web.1]:     at /app/index.js:26:6
> 2016-10-07T07:21:44.821848+00:00 app[web.1]:     at Layer.handle [as handle_request](/app/node_modules/express/lib/router/layer.js:95:5)
> 2016-10-07T07:21:44.821848+00:00 app[web.1]:     at next (/app/node_modules/express/lib/router/route.js:131:13)
> 2016-10-07T07:21:44.821849+00:00 app[web.1]:     at Route.dispatch (/app/node_modules/express/lib/router/route.js:112:3)
> 2016-10-07T07:21:44.821850+00:00 app[web.1]:     at Layer.handle [as handle_request](/app/node_modules/express/lib/router/layer.js:95:5)
> 2016-10-07T07:21:44.821851+00:00 app[web.1]:     at /app/node_modules/express/lib/router/index.js:277:22
> 2016-10-07T07:21:44.821851+00:00 app[web.1]:     at Function.process_params (/app/node_modules/express/lib/router/index.js:330:12)
