### PR TITLE
fix access token environment variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ app.post('/webhook/', function (req, res) {
 
 
 // recommended to inject access tokens as environmental variables, e.g.
-// const token = process.env.PAGE_ACCESS_TOKEN
+// const token = process.env.FB_PAGE_ACCESS_TOKEN
 const token = "<PAGE_ACCESS_TOKEN>"
 
 function sendTextMessage(sender, text) {


### PR DESCRIPTION
README.md refers to the environment variable as `FB_PAGE_ACCESS_TOKEN` but code looks for `PAGE_ACCESS_TOKEN`. took me a few minutes to figure that out :upside_down_face: 
